### PR TITLE
Fix factual errors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ A Claude Code skill for generating and editing images using the Gemini CLI's nan
 ### 1. Install the Gemini CLI
 
 ```bash
-npm install -g @anthropic-ai/gemini-cli
+npm install -g @google/gemini-cli
 ```
 
 ### 2. Set your API key
 
 ```bash
-export GEMINI_API_KEY="your-api-key"
+export NANOBANANA_GEMINI_API_KEY="your-api-key"
 ```
 
 ### 3. Install the nanobanana extension
@@ -80,11 +80,10 @@ Once installed, Claude Code will automatically use this skill when you ask for i
 
 | Option | Description |
 |--------|-------------|
-| `--yolo` | Auto-approve tool actions (no prompts) |
 | `--count=N` | Generate N variations (1-8) |
 | `--preview` | Auto-open generated images |
 | `--styles="style1,style2"` | Apply artistic styles |
-| `--format=grid\|separate` | Output arrangement |
+| `--seed=N` | Seed for reproducible results |
 
 ## Output
 


### PR DESCRIPTION
- Fix npm package name: @anthropic-ai/gemini-cli → @google/gemini-cli
- Fix API key env var: GEMINI_API_KEY → NANOBANANA_GEMINI_API_KEY (recommended by the extension)
- Remove --yolo from Common Options (it's a Gemini CLI flag, not a nanobanana option)
- Replace non-existent --format option with real --seed option

https://claude.ai/code/session_01FbaAVg1hm5nxX6psB5Yg1y